### PR TITLE
M-x racket-base-requires and M-x whitespace-cleanup

### DIFF
--- a/HTML-Element.rkt
+++ b/HTML-Element.rkt
@@ -1,17 +1,17 @@
-#lang racket
+#lang racket/base
 
-(require net/url
-         net/url-connect
-         openssl
-         rackunit
-         racket/pretty
-         "list-utils.rkt" ; for atom?
-         "web.rkt"        ; for web/call
-         "try.rkt"
-         html-parsing
+(require html-parsing
+         net/url
+         racket/contract/base
+         racket/contract/region
+         racket/format
+         racket/list
+         racket/string
          sxml
+         "list-utils.rkt"
+         "try.rkt"
          "utils.rkt"
-         )
+         "web.rkt")
 
 (provide (all-defined-out)
          (all-from-out sxml))

--- a/db.rkt
+++ b/db.rkt
@@ -1,13 +1,19 @@
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require db
-         "utils.rkt"
+(require (for-syntax racket/base)
+         db
+         racket/contract/base
+         racket/contract/region
+         racket/dict
+         racket/format
+         racket/function
+         racket/list
+         racket/match
+         "exceptions.rkt"
          "list-utils.rkt"
          "sql.rkt"
          "try.rkt"
-         "exceptions.rkt"
-         )
-
+         "utils.rkt")
 
 ;======================================================================
 ;  A collection of convenience functions for working with the DB.

--- a/exceptions.rkt
+++ b/exceptions.rkt
@@ -1,14 +1,16 @@
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require (for-syntax syntax/parse))
+(require (for-syntax racket/base)
+         racket/contract/base
+         racket/contract/region
+         racket/format)
 
 (provide (struct-out exn:fail:insufficient-space)
          exn:fail:insufficient-space/c
          exn:fail:insufficient-space/kw
          create-exn
          create/raise-exn
-         verify-arg
-         )
+         verify-arg)
 
 ;;======================================================================
 ;;  Functions for easy creation and management of exceptions, as well

--- a/files/compression.rkt
+++ b/files/compression.rkt
@@ -1,16 +1,17 @@
-#lang racket
+#lang racket/base
 
-(require file/gzip
+(require (for-syntax racket/base)
          file/gunzip
-         handy/utils
+         file/gzip
          handy/try
-         )
+         handy/utils
+         racket/contract/base
+         racket/contract/region)
 
 (provide gzip*
          gunzip*
          (struct-out exn:fail:gunzip)
-         (all-from-out file/gzip file/gunzip)
-         )
+         (all-from-out file/gzip file/gunzip))
 
 (struct exn:fail:gunzip exn:fail ())
 
@@ -81,7 +82,7 @@
            (lambda (file archive-supplied?)
              (define result (path-string->string (output-path-or-maker file archive-supplied?)))
              (set! out-filepath result)
-             result)]             
+             result)]
           [else
            (lambda (file archive-supplied?)
              (define result  (build-path out-dir file))

--- a/fsmonitor.rkt
+++ b/fsmonitor.rkt
@@ -1,8 +1,10 @@
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "try.rkt"
-         "utils.rkt"
-         )
+(require racket/contract/base
+         racket/contract/region
+         racket/file
+         racket/format
+         "utils.rkt")
 
 (provide watch-dir-or-tree)
 

--- a/hash.rkt
+++ b/hash.rkt
@@ -1,7 +1,15 @@
-#lang racket
+#lang racket/base
 
-(require racket/hash) ; for hash-union
+(require racket/bool
+         racket/contract/base
+         racket/contract/region
+         racket/format
+         racket/function
+         racket/hash
+         racket/list
+         racket/match)
 
+ ; for hash-union
 ;; *) hash->keyword-apply : take a function and a hash.  Assume the
 ;;     keys of the hash are keyword arguments and call appropriately.
 ;; *) hash-key-exists?    : alias for hash-has-key? because I always forget the name

--- a/info.rkt
+++ b/info.rkt
@@ -8,7 +8,5 @@
                "base"
                "db-lib"
                "rackunit-lib"
-               "sxml"
-               ))
-(define build-deps '("at-exp-lib"
-                     ))
+               "sxml"))
+(define build-deps '("at-exp-lib"))

--- a/json.rkt
+++ b/json.rkt
@@ -1,12 +1,15 @@
-#lang racket
+#lang racket/base
 
-(require json
-         "try.rkt"
-         )
+(require (for-syntax racket/base)
+         json
+         racket/contract/base
+         racket/contract/region
+         racket/function
+         racket/string
+         "try.rkt")
 
 (provide valid-json?
-         (all-from-out json)
-         )
+         (all-from-out json))
 
 ;;======================================================================
 ;;    See the Racket-standard 'json' module for more.

--- a/list-utils.rkt
+++ b/list-utils.rkt
@@ -1,8 +1,17 @@
-#lang racket
+#lang racket/base
 
-(require (only-in handy/hash hash->keyword-apply)
-         handy/deprecated/list-utils
-         )
+(require handy/deprecated/list-utils
+         (only-in handy/hash
+                  hash->keyword-apply)
+         racket/bool
+         racket/contract/base
+         racket/contract/region
+         racket/dict
+         racket/function
+         racket/list
+         racket/match
+         racket/sequence
+         racket/stream)
 
 (provide (all-defined-out)
          (all-from-out handy/hash)

--- a/sql.rkt
+++ b/sql.rkt
@@ -1,4 +1,11 @@
-#lang at-exp racket
+#lang at-exp racket/base
+
+(require racket/contract/base
+         racket/contract/region
+         racket/format
+         racket/function
+         racket/list
+         racket/string)
 
 (provide (all-defined-out))
 

--- a/struct.rkt
+++ b/struct.rkt
@@ -1,18 +1,20 @@
-#lang racket
+#lang racket/base
 
 ;;    syntax->keyword and struct/kw were lifted from:
 ;;
 ;; http://www.greghendershott.com/2015/07/keyword-structs-revisited.html
 
-(require (for-syntax racket/syntax
+(require (for-syntax racket/base
+                     racket/syntax
                      syntax/parse)
-         "list-utils.rkt"
-         )
+         racket/contract/base
+         racket/contract/region
+         racket/function
+         "list-utils.rkt")
 
 (provide struct/kw
          hash->struct/kw
-         verify-struct
-         )
+         verify-struct)
 
 ;;; Example usage:
 ;;

--- a/t/HTML-Element.t
+++ b/t/HTML-Element.t
@@ -1,15 +1,13 @@
 #!/usr/bin/env racket
 
-#lang racket
+#lang racket/base
 
-(require "../HTML-Element.rkt"
-         "../test-more.rkt"
-         html-parsing
+(require html-parsing
+         racket/list
          racket/runtime-path
          sxml
-         "../list-utils.rkt"
-         )
-
+         "../HTML-Element.rkt"
+         "../test-more.rkt")
 
 (define-runtime-path thisdir ".")
 (define test-file (build-path thisdir "some_HTML-Element_test_data.html"))
@@ -100,7 +98,7 @@
    (ok (xexp? (html->xexp "")) "xexp? identifies something empty element")
    ))
 
-   
+
 (when #t
   (test-suite
    "attr-hash: make attribute hashes from elements and attribute lists"

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -1,12 +1,12 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "../utils.rkt"
-         "../try.rkt"
-         "../test-more.rkt"
+(require racket/contract/base
+         racket/format
+         racket/function
          "../exceptions.rkt"
-         )
+         "../test-more.rkt")
 
 (ok #t "test harness is working")
 
@@ -15,17 +15,17 @@
 
  (lives (thunk (exn:fail:insufficient-space/kw
                 #:requested 7
-                #:available 8 
+                #:available 8
                 #:request-source 'foo))
         "happy path of exn:fail:insufficient-space/kw lives")
  (define exn
    (lives (thunk (exn:fail:insufficient-space/kw
                   #:msg "overruled!"
                   #:requested 7
-                  #:available 8 
+                  #:available 8
                   #:request-source 'foo))
           "happy path of exn:fail:insufficient-space/kw lives"))
- (like (exn-message exn) #px"overruled!" "successfully overruled message") 
+ (like (exn-message exn) #px"overruled!" "successfully overruled message")
  )
 
 (when #t
@@ -42,9 +42,9 @@
           @~a{Lives: (verify-arg "next-piece" 'apple (or/c 'apple 'pear) 'check-fruit-type)}
           )
 
-   (throws (thunk 
+   (throws (thunk
             (verify-arg "requested-space" 'bob exact-positive-integer? 'has-sufficient-space))
-           @pregexp{has-sufficient-space:\s+'requested-space' must be exact-positive-integer\?\s+requested-space:\s+'bob}   
+           @pregexp{has-sufficient-space:\s+'requested-space' must be exact-positive-integer\?\s+requested-space:\s+'bob}
            @~a{throws expected message: (verify-arg "requested-space" 'bob exact-positive-integer? 'has-sufficient-space)})
    ;; )
 

--- a/t/files-compression.t
+++ b/t/files-compression.t
@@ -1,11 +1,14 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require handy/utils
+(require handy/files/compression
          handy/test-more
-         handy/files/compression
-         )
+         handy/utils
+         racket/file
+         racket/format
+         racket/function)
+
 (expect-n-tests 39)
 
 (void (ok 1 "test harness working"))

--- a/t/fsmonitor.t
+++ b/t/fsmonitor.t
@@ -1,15 +1,11 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "../test-more.rkt"
-         "../utils.rkt"
-         "../fsmonitor.rkt"
-         db
+(require db
+         racket/file
          racket/runtime-path
-		 )
-
-
+         "../test-more.rkt")
 
 (define-runtime-path thisdir ".")
 (define-runtime-path testdir "./data-fsmonitor-test-data")

--- a/t/hash.t
+++ b/t/hash.t
@@ -1,9 +1,12 @@
 #!/usr/bin/env racket
 
-#lang racket
+#lang racket/base
 
 (require handy/hash
-         handy/test-more)
+         handy/test-more
+         racket/bool
+         racket/format
+         racket/function)
 
 (expect-n-tests 112)
 

--- a/t/json.t
+++ b/t/json.t
@@ -1,12 +1,12 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "../utils.rkt"
+(require racket/format
+         racket/function
+         racket/list
          "../json.rkt"
-         "../test-more.rkt"
-         json
-		 )
+         "../test-more.rkt")
 
 (ok #t "testing harness works")
 

--- a/t/list-utils.t
+++ b/t/list-utils.t
@@ -1,10 +1,13 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "../list-utils.rkt"
-         "../test-more.rkt"
-         )
+(require racket/bool
+         racket/format
+         racket/function
+         racket/list
+         "../list-utils.rkt"
+         "../test-more.rkt")
 
 (expect-n-tests 267)
 
@@ -85,7 +88,7 @@
    (is (safe-first* '((8))) 8  "(safe-first* '((8))) is 8")
 
 
-   
+
    (is (safe-rest '(foo bar)) '(bar) "safe-rest '(foo bar) is '(bar)")
    (is (safe-rest '()) '() "safe-rest '() is '()")
    (for ((args (list (cons 1 2) 'a 7)))
@@ -519,7 +522,7 @@
    (is (sort-smart  '(#t #f #f #t) #:asc? #f)
        '(#f #f #t #t)
        "sort-smart handles bools and sorts reversed")
-   
+
    (define bad-lst  (list 7 8 'a "x"))
    (for ((f (list sort-num sort-str sort-sym sort-smart)))
      (throws (thunk (f bad-lst))

--- a/t/some_HTML-Element_test_data.html
+++ b/t/some_HTML-Element_test_data.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-	<h1>Hello, world</h1>
+    <h1>Hello, world</h1>
   </body>
-  
+
 </html>

--- a/t/sql.t
+++ b/t/sql.t
@@ -1,11 +1,11 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-
-(require "../test-more.rkt"
+(require racket/format
+         racket/function
          "../sql.rkt"
-         )
+         "../test-more.rkt")
 
 (expect-n-tests 34)
 
@@ -60,8 +60,8 @@
        "collaborations c JOIN collaborations_to_files c2f ON c.id = c2f.collaboration_id JOIN files f ON c2f.file_id = f.id JOIN collaborations_to_endpoints c2e ON c.id = c2e.collaboration_id JOIN endpoints e ON c2e.endpoint_id = e.id JOIN collaborations_to_users c2u ON c.id = c2u.collaboration_id JOIN users u ON c2u.user_id = u.id"
        "(many-to-many-join \"collaborations\" '(\"files\" \"endpoints\" \"users\")) works")
 
-   
-   
+
+
   (is (many-to-many-natural-join c f)
        "collaborations c NATURAL JOIN collaborations_to_files c2f NATURAL JOIN files f"
        "many-to-many-natural-join works")

--- a/t/struct.t
+++ b/t/struct.t
@@ -1,10 +1,12 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "../struct.rkt"
-         "../test-more.rkt"
-         )
+(require racket/format
+         racket/function
+         racket/match
+         "../struct.rkt"
+         "../test-more.rkt")
 
 (expect-n-tests 36)
 
@@ -131,5 +133,3 @@
 
    (ok (verify-struct #:struct x #:type foo?) "validates when given a type predicate")
    ))
-
-

--- a/t/test-more.t
+++ b/t/test-more.t
@@ -1,8 +1,15 @@
 #!/usr/bin/env racket
 
-#lang racket
-(require "../test-more.rkt"
-         (only-in handy/utils say))
+#lang racket/base
+(require (only-in handy/utils
+                  say)
+         racket/bool
+         racket/file
+         racket/format
+         racket/function
+         racket/list
+         racket/port
+         "../test-more.rkt")
 
 (expect-n-tests 177)
 

--- a/t/try.t
+++ b/t/try.t
@@ -1,8 +1,9 @@
 #!/usr/bin/env racket
 
-#lang racket
+#lang racket/base
 
-(require "../test-more.rkt"
+(require racket/function
+         "../test-more.rkt"
          "../try.rkt")
 
 (expect-n-tests 22)
@@ -121,6 +122,3 @@
           "defatalized a (raise-argument-error)")
    )
   )
-
-
-

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env racket
 
-#lang at-exp racket
+#lang at-exp racket/base
 
 ;;   NOTE: There's a bunch of tests in here for the 'handy/hash'
 ;;   functions.  These tests are redundant with the ones in hash.t
@@ -10,10 +10,14 @@
 ;;   require just handy/hash if you don't want the other stuff from
 ;;   utils.
 
-(require "../utils.rkt"
-         "../test-more.rkt"
+(require racket/file
+         racket/format
+         racket/function
+         racket/port
+         racket/promise
          racket/runtime-path
-         )
+         "../test-more.rkt"
+         "../utils.rkt")
 
 (expect-n-tests 293)
 

--- a/t/web.t
+++ b/t/web.t
@@ -1,12 +1,14 @@
 #!/usr/bin/env racket
 
-#lang racket
+#lang racket/base
 
 (require net/url
+         racket/function
+         racket/port
          racket/runtime-path
          "../HTML-Element.rkt"
-         "../web.rkt"
-         "../test-more.rkt")
+         "../test-more.rkt"
+         "../web.rkt")
 
 ;;    Constants for tests
 (define-runtime-path main-path  "data/20160802_Latest_EDGAR_Filings/main_page.html")

--- a/test-more.rkt
+++ b/test-more.rkt
@@ -1,7 +1,15 @@
-#lang racket
+#lang racket/base
 
-(require handy/utils
-         )
+(require (for-syntax racket/base)
+         handy/utils
+         racket/bool
+         racket/contract/base
+         racket/contract/region
+         racket/file
+         racket/format
+         racket/function
+         racket/match
+         racket/string)
 
 (provide prefix-for-test-report ; parameter printed at start of each test
          prefix-for-diag        ; parameter printed at front of each (diag ...) message

--- a/thread.rkt
+++ b/thread.rkt
@@ -1,10 +1,13 @@
-#lang racket
+#lang racket/base
 
-(require "utils.rkt")
+(require racket/contract/base
+         racket/contract/region
+         racket/format
+         racket/function
+         "utils.rkt")
 
 (provide execute-thunk
-         threaded
-         )
+         threaded)
 
 ;;======================================================================
 ;;    Functions for conveniently threading your code.
@@ -32,7 +35,7 @@
 
   (define current-prefix (prefix-for-say))
 
-  (define thread-label 
+  (define thread-label
     (cond [(empty-string? current-prefix) (~a (rand-val "thread") ": ")]
           [else (~a (rand-val "thread") " / " current-prefix)]))
 

--- a/try.rkt
+++ b/try.rkt
@@ -1,6 +1,8 @@
-#lang racket
+#lang racket/base
 
-(require (for-syntax syntax/parse))
+(require (for-syntax racket/base
+                     syntax/parse)
+         racket/function)
 
 ;;  PURPOSE: Racket's with-handlers has poor end weight; it puts the
 ;;  error conditions first, distracting from the actual point of the

--- a/utils.rkt
+++ b/utils.rkt
@@ -1,6 +1,17 @@
-#lang at-exp racket
+#lang at-exp racket/base
 
-(require "hash.rkt")
+(require (for-syntax racket/base)
+         racket/bool
+         racket/contract/base
+         racket/contract/region
+         racket/file
+         racket/format
+         racket/function
+         racket/match
+         racket/path
+         racket/port
+         racket/promise
+         "hash.rkt")
 
 (provide (all-from-out "hash.rkt")
          prefix-for-say

--- a/web.rkt
+++ b/web.rkt
@@ -1,8 +1,13 @@
-#lang racket
+#lang racket/base
 
-(require net/url
-         html-parsing
-         )
+(require html-parsing
+         net/url
+         racket/bool
+         racket/contract/base
+         racket/contract/region
+         racket/function
+         racket/port
+         racket/system)
 
 ;;----------------------------------------------------------------------
 ;;    Check if a url-ish thing refers to a local resource or one on


### PR DESCRIPTION
Using #lang racket/base typically uses less memory and starts faster --
especially when developing interactively.